### PR TITLE
Expected health

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -25,7 +25,7 @@ let borderPadding = borderUISize / 3;
 let oceanSpeed = 5;
 
 // controls
-let keyRIGHT, keyUP, keyDOWN, keyENTER;
+let keyRIGHT, keyUP, keyDOWN, keyENTER, keySHIFT;
 /*
 CMPM 120
 Iron Sites

--- a/src/prefabs/Enemy.js
+++ b/src/prefabs/Enemy.js
@@ -9,6 +9,7 @@ class Enemy extends Phaser.Physics.Arcade.Sprite {
         this.body.onCollide = true;
         this.body.setImmovable(true);
         this.health = 100;
+        this.expectedDamage = 0; // the amount of damage that will come from turret shots already aimed
         this.isDead = false;
 
         this.environment = environment;

--- a/src/prefabs/Player.js
+++ b/src/prefabs/Player.js
@@ -21,7 +21,7 @@ class Player extends Phaser.Physics.Arcade.Sprite {
         else {
             this.setAngularVelocity(0);
         }
-        if(keyRIGHT.isDown && this.ready == true){
+        if((keyRIGHT.isDown || keySHIFT.isDown) && this.ready == true){
             let newShot = new PlayerShot(this.scene, this.x + this.width/2 * Math.cos(this.rotation), this.y + this.height/2 * Math.sin(this.rotation), 'shot', this.rotation).setOrigin(0.5, 0.5);
             this.shots.add(newShot);
             this.scene.throwingSfx.play();

--- a/src/prefabs/Turret.js
+++ b/src/prefabs/Turret.js
@@ -2,7 +2,7 @@
 // Then, on click, it can be upgraded into an actual tower.
 // Once ugpraded, can no longer be interactable.
 class Turret extends Phaser.Physics.Arcade.Sprite {
-    constructor(scene, x, y, enemies, shots) {
+    constructor(scene, x, y, enemies) {
         super(scene, x, y, 'blank');
 
         this.setButcher = this.setButcher.bind(this); //must BIND these functions in order 
@@ -10,7 +10,6 @@ class Turret extends Phaser.Physics.Arcade.Sprite {
 
         this.scene = scene;
         this.enemies = enemies;
-        //this.shots = shots;
         this.shots = scene.add.group({
             runChildUpdate: true
         });

--- a/src/prefabs/TurretShot.js
+++ b/src/prefabs/TurretShot.js
@@ -1,7 +1,12 @@
 class TurretShot extends Phaser.Physics.Arcade.Sprite {
-    constructor(scene, x, y, texture, rotation, target) {
+    constructor(scene, x, y, texture, rotation, target, damage) {
         super(scene, x, y, texture);
+        this.target += this.damage;
         this.target = target;
+        this.s = scene;
+        this.target.expectedDamage += damage;
+        console.log(target, target.expectedDamage, target.health);
+        this.damage = damage;
         scene.add.existing(this);
         scene.physics.add.existing(this);
         this.rotation = rotation;
@@ -20,6 +25,17 @@ class TurretShot extends Phaser.Physics.Arcade.Sprite {
 
         if(this.target.isDead){
             this.destroy();
+        }
+
+        this.s.physics.world.overlap(this.target, this, this.enemyHit, null, this);
+    }
+
+    enemyHit(enemy, shot){
+        shot.destroy();
+        enemy.expectedDamage -= this.damage;
+        enemy.health -= this.damage; //deal damage
+        if(enemy.health <= 0){
+            enemy.enemyDeath();
         }
     }
 }

--- a/src/scenes/Play.js
+++ b/src/scenes/Play.js
@@ -49,6 +49,8 @@ class Play extends Phaser.Scene {
 
         // Tower
         this.tower = new Tower(this, game.config.width / 2, game.config.height - 100, 'tower').setOrigin(0.5, 0.5);
+
+        //Enemy groups
         this.enemyLeft = this.add.group({
             runChildUpdate: true
         });
@@ -76,7 +78,7 @@ class Play extends Phaser.Scene {
             loop: false 
         });
 
-        //The player character's shots
+        //The player character and turret's shots
         this.shots = this.add.group({
             runChildUpdate: true
         });
@@ -119,8 +121,8 @@ class Play extends Phaser.Scene {
         this.turret.update();
         this.turret2.update();
         
-        this.physics.world.overlap(this.enemyRight, this.shots, this.enemyHitByPlayer, null, this);
-        this.physics.world.overlap(this.enemyLeft, this.shots, this.enemyHitByPlayer, null, this);
+        //this.physics.world.overlap(this.enemyRight, this.shots, this.enemyHitByPlayer, null, this);
+        //this.physics.world.overlap(this.enemyLeft, this.shots, this.enemyHitByPlayer, null, this);
         // checks collision on the tower
         this.physics.world.collide(this.tower, this.enemyLeft, this.collisionOccurred, null, this);
         this.physics.world.collide(this.tower, this.enemyRight, this.collisionOccurred, null, this);

--- a/src/scenes/Play.js
+++ b/src/scenes/Play.js
@@ -46,6 +46,7 @@ class Play extends Phaser.Scene {
         keyDOWN = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.DOWN);
         keyRIGHT = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.RIGHT);
         keyENTER = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ENTER);
+        keySHIFT = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SHIFT);
 
         // Tower
         this.tower = new Tower(this, game.config.width / 2, game.config.height - 100, 'tower').setOrigin(0.5, 0.5);
@@ -84,8 +85,8 @@ class Play extends Phaser.Scene {
         });
 
         this.player = new Player(this, game.config.width / 2, game.config.height / 4, 'player', this.shots).setOrigin(0.5, 0.5);
-        this.turret = new Turret(this, 3 * game.config.width/5, 2*game.config.height/5, this.enemyRight, this.shots).setOrigin(0.5, 0.5);
-        this.turret2 = new Turret(this, 2 * game.config.width/5, 2*game.config.height/5, this.enemyLeft, this.shots).setOrigin(0.5, 0.5);
+        this.turret = new Turret(this, 3 * game.config.width/5, 2*game.config.height/5, this.enemyRight).setOrigin(0.5, 0.5);
+        this.turret2 = new Turret(this, 2 * game.config.width/5, 2*game.config.height/5, this.enemyLeft).setOrigin(0.5, 0.5);
 
         this.environmentTypes = ["Sea", "Sky", "Shore"];
 
@@ -121,8 +122,8 @@ class Play extends Phaser.Scene {
         this.turret.update();
         this.turret2.update();
         
-        //this.physics.world.overlap(this.enemyRight, this.shots, this.enemyHitByPlayer, null, this);
-        //this.physics.world.overlap(this.enemyLeft, this.shots, this.enemyHitByPlayer, null, this);
+        this.physics.world.overlap(this.enemyRight, this.shots, this.enemyHitByPlayer, null, this);
+        this.physics.world.overlap(this.enemyLeft, this.shots, this.enemyHitByPlayer, null, this);
         // checks collision on the tower
         this.physics.world.collide(this.tower, this.enemyLeft, this.collisionOccurred, null, this);
         this.physics.world.collide(this.tower, this.enemyRight, this.collisionOccurred, null, this);
@@ -136,8 +137,10 @@ class Play extends Phaser.Scene {
 
     enemyHitByPlayer(enemy, shot){
         shot.destroy();
-        enemy.enemyDeath();
-        enemy.health -= 1; //deal damage
+        enemy.health -= 50; //deal damage
+        if(enemy.health <= 0){
+            enemy.enemyDeath();
+        }
     }
 
     collisionOccurred() {


### PR DESCRIPTION
Turrets that shoot bullets now deal "expected damage" when fired, and when an enemy has less health than expected damage, it is no longer targeted.  
Also moved the collision detection from the Play scene to the individual bullets, except for the player.  This means that the turret's shots will not collide with enemies that they do not have targeted, which greatly simplifies these calculations.  The player's shots can still hit anything, and are not a part of the expectation calculations.
Bullets still disappear when outside influences change the health (such as the player).